### PR TITLE
Add localstore service module

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,18 +1,14 @@
 import React from "react";
 import ReactDom from "react-dom";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import localforage from "localforage";
+import localstoreConfig from "./services/localstore";
 import "./styles/base.css";
 import "whatwg-fetch";
 
 import { ActivePlayerProvider } from "./context/ActivePlayer";
 import * as Pages from "./pages";
 
-localforage.config({
-  description: "Apex Legends player stats tracker",
-  name: "legend-alert",
-  storeName: "players"
-});
+localstoreConfig();
 
 const App = () => (
   <ActivePlayerProvider>

--- a/src/context/ActivePlayer.js
+++ b/src/context/ActivePlayer.js
@@ -15,14 +15,14 @@ const ActivePlayerProvider = props => {
     const players = await localstore.getAllEntries();
 
     // players is an array of objects keyed by platformUserId, each item
-    // has a Tracker Network search result object as their value
+    // has a select fields from a Tracker Network search result object as their value
     const player = players.length
       ? players.find(player => {
           return Object.values(player).find(({ isActive }) => isActive);
         })
       : undefined;
 
-    // Return the Tracker Network search result object
+    // Return the Tracker Network search response data
     return player ? Object.values(player)[0] : undefined;
   });
 
@@ -67,11 +67,9 @@ const ActivePlayerProvider = props => {
 
     setActivePlayer(activePlayer);
 
-    try {
-      localstore.setItem(player.platformUserId, activePlayer);
-    } catch (err) {
-      console.warn("Something went wrong writing to local", err);
-    }
+    localstore
+      .setItem(player.platformUserId, activePlayer)
+      .catch(err => console.warn("Something went wrong writing to local", err));
   });
 
   // Runs once on app mount
@@ -97,11 +95,11 @@ const ActivePlayerProvider = props => {
 };
 
 const useActivePlayer = () => {
-  const { activePlayer, getActivePlayer, setActivePlayer } = React.useContext(
+  const { activePlayer, setActivePlayer } = React.useContext(
     ActivePlayerContext
   );
 
-  return [activePlayer, { getActivePlayer, setActivePlayer }];
+  return [activePlayer, setActivePlayer];
 };
 
 export { ActivePlayerProvider, useActivePlayer };

--- a/src/context/ActivePlayer.js
+++ b/src/context/ActivePlayer.js
@@ -1,28 +1,76 @@
 import React from "react";
-import localforage from "localforage";
+import { localstore } from "../services";
 
 const ActivePlayerContext = React.createContext();
 
 const ActivePlayerProvider = props => {
   const [activePlayer, setActivePlayer] = React.useState(null);
 
+  /**
+   * Retrieve the last active player stored in offline storage
+   *
+   * @return {Object|undefined} Tracker Network player search result or undefined
+   */
+  const getActivePlayerFromStorage = React.useRef(async () => {
+    const players = await localstore.getAllEntries();
+
+    // The below two blocks could be considered confusing
+    const player = players.length
+      ? players.find(player => {
+          return Object.values(player).find(({ isActive }) => isActive);
+        })
+      : undefined;
+
+    return player ? Object.values(player)[0] : undefined;
+  });
+
+  /**
+   * Set the active player
+   *
+   * @param  {Object}  player Tracker Network player search response object
+   * @return {Promise}        Resolves with item being stored, rejects on error encountered
+   */
+  const onSetActivePlayer = React.useRef(async player => {
+    const _activePlayer = Object.assign({}, player, { isActive: true });
+
+    setActivePlayer(_activePlayer);
+
+    try {
+      await localstore.setItem(player.platformUserId, _activePlayer);
+    } catch (err) {
+      console.warn("Something went wrong writing to local", err);
+    }
+  });
+
+  // Runs once on app mount
   React.useEffect(() => {
-    localforage
-      .getItem("activePlayer")
-      .then(setActivePlayer)
+    getActivePlayerFromStorage
+      .current()
+      .then(player => player && onSetActivePlayer.current(player))
       .catch(err =>
         console.warn("Something went wrong getting the last legend", err)
       );
   }, []);
 
   return (
-    <ActivePlayerContext.Provider value={activePlayer}>
+    <ActivePlayerContext.Provider
+      value={{
+        activePlayer,
+        setActivePlayer: onSetActivePlayer.current
+      }}
+    >
       {props.children}
     </ActivePlayerContext.Provider>
   );
 };
 
-const useActivePlayer = () => React.useContext(ActivePlayerContext);
+const useActivePlayer = () => {
+  const { activePlayer, getActivePlayer, setActivePlayer } = React.useContext(
+    ActivePlayerContext
+  );
+
+  return [activePlayer, { getActivePlayer, setActivePlayer }];
+};
 
 export { ActivePlayerProvider, useActivePlayer };
 export default ActivePlayerContext;

--- a/src/context/ActivePlayer.js
+++ b/src/context/ActivePlayer.js
@@ -33,7 +33,7 @@ const ActivePlayerProvider = props => {
    * @return {Promise}        Resolves with item being stored, rejects on error encountered
    */
   const onSetActivePlayer = React.useRef(async player => {
-    const currentActivePlayer = await getActivePlayerFromLocalstore.current()
+    const currentActivePlayer = await getActivePlayerFromLocalstore.current();
 
     // If current active player in offline storage is the same, only update state
     if (
@@ -43,10 +43,15 @@ const ActivePlayerProvider = props => {
       return setActivePlayer(_activePlayer);
     } else if (currentActivePlayer) {
       // Set active player in offline storage to inactive
-      const inactivePlayer = Object.assign({}, currentActivePlayer, { isActive: false });
+      const inactivePlayer = Object.assign({}, currentActivePlayer, {
+        isActive: false
+      });
 
       try {
-        await localstore.setItem(currentActivePlayer.platformUserId, inactivePlayer);
+        await localstore.setItem(
+          currentActivePlayer.platformUserId,
+          inactivePlayer
+        );
       } catch (err) {
         console.warn("Something went wrong writing to local", err);
       }

--- a/src/context/ActivePlayer.js
+++ b/src/context/ActivePlayer.js
@@ -30,13 +30,13 @@ const ActivePlayerProvider = props => {
    * @param  {Object}  player Tracker Network player search response object
    * @return {Promise}        Resolves with item being stored, rejects on error encountered
    */
-  const onSetActivePlayer = React.useRef(async player => {
+  const onSetActivePlayer = React.useRef(player => {
     const _activePlayer = Object.assign({}, player, { isActive: true });
 
     setActivePlayer(_activePlayer);
 
     try {
-      await localstore.setItem(player.platformUserId, _activePlayer);
+      localstore.setItem(player.platformUserId, _activePlayer);
     } catch (err) {
       console.warn("Something went wrong writing to local", err);
     }

--- a/src/context/ActivePlayer.js
+++ b/src/context/ActivePlayer.js
@@ -33,23 +33,31 @@ const ActivePlayerProvider = props => {
    * @return {Promise}        Resolves with item being stored, rejects on error encountered
    */
   const onSetActivePlayer = React.useRef(async player => {
-    const currentActivePlayer = await getActivePlayerFromLocalstore.current();
+    const localActivePlayer = await getActivePlayerFromLocalstore.current();
+    const activePlayer = Object.assign(
+      {},
+      {
+        platformSlug: player.platformSlug,
+        platformUserId: player.platformUserId.toLowerCase()
+      },
+      { isActive: true }
+    );
 
     // If current active player in offline storage is the same, only update state
     if (
-      currentActivePlayer &&
-      currentActivePlayer.platformUserId === player.platformUserId
+      localActivePlayer &&
+      localActivePlayer.platformUserId === activePlayer.platformUserId
     ) {
-      return setActivePlayer(_activePlayer);
-    } else if (currentActivePlayer) {
+      return setActivePlayer(activePlayer);
+    } else if (localActivePlayer) {
       // Set active player in offline storage to inactive
-      const inactivePlayer = Object.assign({}, currentActivePlayer, {
+      const inactivePlayer = Object.assign({}, localActivePlayer, {
         isActive: false
       });
 
       try {
         await localstore.setItem(
-          currentActivePlayer.platformUserId,
+          localActivePlayer.platformUserId,
           inactivePlayer
         );
       } catch (err) {
@@ -57,12 +65,10 @@ const ActivePlayerProvider = props => {
       }
     }
 
-    const _activePlayer = Object.assign({}, player, { isActive: true });
-
-    setActivePlayer(_activePlayer);
+    setActivePlayer(activePlayer);
 
     try {
-      localstore.setItem(player.platformUserId, _activePlayer);
+      localstore.setItem(player.platformUserId, activePlayer);
     } catch (err) {
       console.warn("Something went wrong writing to local", err);
     }

--- a/src/context/ActivePlayer.js
+++ b/src/context/ActivePlayer.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { localstore } from "../services";
 
 const ActivePlayerContext = React.createContext();
@@ -92,6 +93,10 @@ const ActivePlayerProvider = props => {
       {props.children}
     </ActivePlayerContext.Provider>
   );
+};
+
+ActivePlayerProvider.propTypes = {
+  children: PropTypes.node.isRequired
 };
 
 const useActivePlayer = () => {

--- a/src/pages/PlayerSearch/components/PlayerSearchResults.js
+++ b/src/pages/PlayerSearch/components/PlayerSearchResults.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import localforage from "localforage";
+import { useActivePlayer } from "../../../context/ActivePlayer";
 import { withRouter } from "react-router-dom";
 
 import {
@@ -10,6 +10,9 @@ import {
 } from "../styles";
 
 const PlayerSearchResults = ({ goBack, history, results = [] }) => {
+  // eslint-disable-next-line no-unused-vars
+  const [_, { setActivePlayer }] = useActivePlayer();
+
   if (!results.length) {
     return (
       <section className="pane">
@@ -27,10 +30,9 @@ const PlayerSearchResults = ({ goBack, history, results = [] }) => {
 
   const onClickGoBack = () => goBack(false);
 
-  const onSelectLegend = async legendIdx => {
-    await localforage.setItem("activePlayer", results[legendIdx]);
+  const onSelectLegend = legendIdx => {
+    setActivePlayer(results[legendIdx]);
 
-    // tmp solution to change route - change to custom event or something
     history.push("/stats");
   };
 

--- a/src/pages/PlayerSearch/components/PlayerSearchResults.js
+++ b/src/pages/PlayerSearch/components/PlayerSearchResults.js
@@ -73,6 +73,7 @@ const PlayerSearchResults = ({ goBack, history, results = [] }) => {
 
 PlayerSearchResults.propTypes = {
   goBack: PropTypes.func.isRequired,
+  history: PropTypes.object,
   results: PropTypes.array
 };
 

--- a/src/pages/PlayerSearch/components/PlayerSearchResults.js
+++ b/src/pages/PlayerSearch/components/PlayerSearchResults.js
@@ -11,7 +11,7 @@ import {
 
 const PlayerSearchResults = ({ goBack, history, results = [] }) => {
   // eslint-disable-next-line no-unused-vars
-  const [_, { setActivePlayer }] = useActivePlayer();
+  const [_, setActivePlayer] = useActivePlayer();
 
   if (!results.length) {
     return (

--- a/src/pages/PlayerSearch/components/ViewActivePlayer.js
+++ b/src/pages/PlayerSearch/components/ViewActivePlayer.js
@@ -3,10 +3,10 @@ import { Link } from "../../../components";
 
 import { viewActivePlayerContainer } from "../styles";
 
-const ViewActivePlayer = ({ player }) => (
+const ViewActivePlayer = ({ playerUserId }) => (
   <div className={viewActivePlayerContainer}>
     <Link to="/stats">
-      <h3>View stats for {player.platformUserHandle}?</h3>
+      <h3>View stats for {playerUserId}?</h3>
     </Link>
   </div>
 );

--- a/src/pages/PlayerSearch/components/ViewActivePlayer.js
+++ b/src/pages/PlayerSearch/components/ViewActivePlayer.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Link } from "../../../components";
 
 import { viewActivePlayerContainer } from "../styles";
@@ -10,5 +11,9 @@ const ViewActivePlayer = ({ playerUserId }) => (
     </Link>
   </div>
 );
+
+ViewActivePlayer.propTypes = {
+  playerUserId: PropTypes.string.isRequired
+};
 
 export default ViewActivePlayer;

--- a/src/pages/PlayerSearch/index.js
+++ b/src/pages/PlayerSearch/index.js
@@ -24,10 +24,12 @@ const PlayerSearch = () => {
 
   return (
     <div className={styles.container}>
+      {activePlayer ? (
+        <Components.ViewActivePlayer
+          playerUserId={activePlayer.platformUserId}
+        />
+      ) : null}
       <section className={styles.contentArea}>
-        {activePlayer ? (
-          <Components.ViewActivePlayer player={activePlayer} />
-        ) : null}
         <div className={styles.logo}>
           <img
             alt="Legend Alert Logo | Siren by Mohamad Arif Prasetyo from the Noun Project"

--- a/src/pages/PlayerSearch/index.js
+++ b/src/pages/PlayerSearch/index.js
@@ -23,30 +23,32 @@ const PlayerSearch = () => {
   }, [networkState]);
 
   return (
-    <section className={styles.container}>
-      {activePlayer ? (
-        <Components.ViewActivePlayer player={activePlayer} />
-      ) : null}
-      <div className={styles.logo}>
-        <img
-          alt="Legend Alert Logo | Siren by Mohamad Arif Prasetyo from the Noun Project"
-          src={logo}
-        />
-      </div>
-      <h1>Legend Alert</h1>
-      <Components.DetailsSlider showResults={showResults}>
-        <div className="slider">
-          <Components.PlayerDetailsForm
-            searching={networkState.loading}
-            submitPlayerSearch={submitPlayerSearch.current}
-          />
-          <Components.PlayerSearchResults
-            goBack={toggleShowReults}
-            results={networkState.data}
+    <div className={styles.container}>
+      <section className={styles.contentArea}>
+        {activePlayer ? (
+          <Components.ViewActivePlayer player={activePlayer} />
+        ) : null}
+        <div className={styles.logo}>
+          <img
+            alt="Legend Alert Logo | Siren by Mohamad Arif Prasetyo from the Noun Project"
+            src={logo}
           />
         </div>
-      </Components.DetailsSlider>
-    </section>
+        <h1>Legend Alert</h1>
+        <Components.DetailsSlider showResults={showResults}>
+          <div className="slider">
+            <Components.PlayerDetailsForm
+              searching={networkState.loading}
+              submitPlayerSearch={submitPlayerSearch.current}
+            />
+            <Components.PlayerSearchResults
+              goBack={toggleShowReults}
+              results={networkState.data}
+            />
+          </div>
+        </Components.DetailsSlider>
+      </section>
+    </div>
   );
 };
 

--- a/src/pages/PlayerSearch/index.js
+++ b/src/pages/PlayerSearch/index.js
@@ -8,7 +8,7 @@ import { useActivePlayer } from "../../context/ActivePlayer";
 import * as Components from "./components";
 
 const PlayerSearch = () => {
-  const activePlayer = useActivePlayer();
+  const [activePlayer] = useActivePlayer();
   const [showResults, toggleShowReults] = React.useState(false);
   const [networkState, doFetch] = useTrackerNetworkAPI();
 

--- a/src/pages/PlayerSearch/styles.js
+++ b/src/pages/PlayerSearch/styles.js
@@ -2,11 +2,14 @@ import { css } from "linaria";
 import leftArrow from "../../images/left-arrow.20x36.svg";
 
 const container = css`
+  background-color: var(--color-offwhite);
+`;
+
+const contentArea = css`
   min-height: 100vh;
   padding: 6.25rem 1rem 3.125rem;
   overflow: hidden;
   position: relative;
-  background-color: var(--color-offwhite);
 
   @media (min-width: 600px) {
     width: 500px;
@@ -115,6 +118,7 @@ export {
   backButton,
   confirmBtn,
   container,
+  contentArea,
   formGroup,
   logo,
   platformChoices,

--- a/src/pages/PlayerStats/components/HeroSection.js
+++ b/src/pages/PlayerStats/components/HeroSection.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { css } from "linaria";
 
 const styles = {
@@ -41,11 +42,11 @@ const styles = {
   `
 };
 
-const HeroSection = ({ image, playerHandle, playerPlatform }) => (
+const HeroSection = ({ image, platformUserId, playerPlatform }) => (
   <section className={styles.container}>
     <div className={styles.playerInfo}>
       <h3 className={styles.playerName}>
-        {playerHandle} | <span className="uppercase">{playerPlatform}</span>
+        {platformUserId} | <span className="uppercase">{playerPlatform}</span>
       </h3>
     </div>
     <div className={styles.legendImage}>
@@ -53,5 +54,11 @@ const HeroSection = ({ image, playerHandle, playerPlatform }) => (
     </div>
   </section>
 );
+
+HeroSection.propTypes = {
+  image: PropTypes.string,
+  platformUserId: PropTypes.string.isRequired,
+  playerPlatform: PropTypes.string.isRequired
+};
 
 export default HeroSection;

--- a/src/pages/PlayerStats/components/StatsGrid.js
+++ b/src/pages/PlayerStats/components/StatsGrid.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { css } from "linaria";
 
 const styles = {
@@ -89,5 +90,9 @@ const StatsGrid = ({ stats }) => (
     </div>
   </section>
 );
+
+StatsGrid.propTypes = {
+  stats: PropTypes.array.isRequired
+};
 
 export default StatsGrid;

--- a/src/pages/PlayerStats/index.js
+++ b/src/pages/PlayerStats/index.js
@@ -6,7 +6,7 @@ import * as utils from "./utils";
 import * as Components from "./components";
 
 const PlayerStats = () => {
-  const activePlayer = useActivePlayer();
+  const [activePlayer] = useActivePlayer();
   const [activeLegend, setActiveLegend] = React.useState(null);
   const [networkState, doFetch] = useTrackerNetworkAPI();
 

--- a/src/pages/PlayerStats/index.js
+++ b/src/pages/PlayerStats/index.js
@@ -51,7 +51,7 @@ const PlayerStats = () => {
     <React.Fragment>
       <Components.HeroSection
         image={activeLegendIconImage}
-        playerHandle={activePlayer.platformUserId}
+        platformUserId={activePlayer.platformUserId}
         playerPlatform={activePlayer.platformSlug}
       />
       <Components.StatsGrid stats={activeLegend.stats} />

--- a/src/pages/PlayerStats/index.js
+++ b/src/pages/PlayerStats/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { useActivePlayer } from "../../context/ActivePlayer";
-
 import useTrackerNetworkAPI from "../../hooks/useTrackerNetworkAPI";
 import * as utils from "./utils";
 import * as Components from "./components";

--- a/src/pages/PlayerStats/index.js
+++ b/src/pages/PlayerStats/index.js
@@ -9,18 +9,18 @@ const PlayerStats = () => {
   const [activeLegend, setActiveLegend] = React.useState(null);
   const [networkState, doFetch] = useTrackerNetworkAPI();
 
-  const fetchPlayerStats = React.useRef((platformSlug, platformUserHandle) => {
+  const fetchPlayerStats = React.useRef((platformSlug, platformUserId) => {
     doFetch(
-      `/apex-api/v1/apex/standard/profile/${platformSlug}/${platformUserHandle}`
+      `/apex-api/v1/apex/standard/profile/${platformSlug}/${platformUserId}`
     );
   });
 
   React.useEffect(() => {
     if (!activePlayer) return;
 
-    const { platformSlug, platformUserHandle } = activePlayer;
+    const { platformSlug, platformUserId } = activePlayer;
 
-    fetchPlayerStats.current(platformSlug, platformUserHandle);
+    fetchPlayerStats.current(platformSlug, platformUserId);
   }, [activePlayer, fetchPlayerStats]);
 
   React.useEffect(() => {
@@ -51,7 +51,7 @@ const PlayerStats = () => {
     <React.Fragment>
       <Components.HeroSection
         image={activeLegendIconImage}
-        playerHandle={activePlayer.platformUserHandle}
+        playerHandle={activePlayer.platformUserId}
         playerPlatform={activePlayer.platformSlug}
       />
       <Components.StatsGrid stats={activeLegend.stats} />

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,3 @@
+import * as localstore from "./localstore";
+
+export { localstore };

--- a/src/services/localstore.js
+++ b/src/services/localstore.js
@@ -1,0 +1,50 @@
+import localforage from "localforage";
+
+/**
+ * Application configuration for offline storage
+ *
+ * @return {Function} localforage config
+ */
+const config = () => {
+  // players store
+  localforage.config({
+    description: "Apex Legends player stats tracker",
+    name: "legend-alert",
+    storeName: "players"
+  });
+};
+
+/**
+ * Store an item
+ *
+ * @param  {String}  key   Entry key for item to be stored
+ * @param  {Any}     value Entry value to be stored
+ * @return {Promise}       Resolves with item being stored, rejects on error encountered
+ */
+const setItem = async (key, value) => {
+  try {
+    await localforage.setItem(key, value);
+  } catch (err) {
+    throw new Error(`Failed to store ${key}, ${err}`);
+  }
+};
+
+/**
+ * Retrieve all items stored in offline storage for the app
+ *
+ * @return {Array} Player objects, keyed by platformUserId
+ */
+const getAllEntries = async () => {
+  try {
+    const players = [];
+
+    await localforage.iterate((value, key) => players.push({ [key]: value }));
+
+    return players;
+  } catch (err) {
+    throw new Error(`Failed to get the active player: ${err}`);
+  }
+};
+
+export { config, getAllEntries, setItem };
+export default config;


### PR DESCRIPTION
- Adds `localstore` service module for handling offline storage, to centralise calls to `localforage`. Currently only used for previous player search results. Going forward it will _potentially_ also store player stats responses
- Updates `ActivePlayer` context to use `localstore` module and provide `setActivePlayer` method to update state
- Standardises field usage from player search response