### PR TITLE
Player stats integration tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,4 @@
-{}
+{
+  "projectId": "skfpyu",
+  "video": false
+}

--- a/cypress/integration/player-search.spec.js
+++ b/cypress/integration/player-search.spec.js
@@ -16,16 +16,16 @@ describe('Integration :: Player Search', () => {
       response: { data: [] }
     }).as('searchLeroyJenkins')
 
-    cy.fixture('player-search-DIRTiG').then(response => {
+    cy.fixture('player-search-DiRTiG').then(response => {
       cy.route({
         url: 'http://localhost:3000/apex-api/v2/apex/standard/search?platform=psn&query=DiRTiG',
         response
       }).as('searchDiRTiG')
     })
 
-    cy.fixture('player-stats-DIRTiG').then(response => {
+    cy.fixture('player-stats-DiRTiG').then(response => {
       cy.route({
-        url: 'http://localhost:3000/apex-api/v1/apex/standard/profile/psn/DiRTiG',
+        url: 'http://localhost:3000/apex-api/v1/apex/standard/profile/psn/dirtig',
         response
       }).as('DiRTiGStatsPage')
     })

--- a/cypress/integration/player-search.spec.js
+++ b/cypress/integration/player-search.spec.js
@@ -10,7 +10,7 @@ describe('Integration :: Player Search', () => {
 
     cy.get('button[data-testid="submit-btn"]').as('submitBtn')
 
-    cy.server({ delay: 500 })
+    cy.server({ delay: 100 })
     cy.route({
       url: 'http://localhost:3000/apex-api/v2/apex/standard/search?platform=psn&query=leroyjenkins',
       response: { data: [] }

--- a/cypress/integration/player-stats.spec.js
+++ b/cypress/integration/player-stats.spec.js
@@ -10,7 +10,7 @@ describe('Integration :: Player Stats', () => {
 
     cy.get('img[data-testid="legend-image"]').as('legendImage')
 
-    cy.get('div[data-testid="stats-grid"] > div[data-testid="stats-item"]').as('statsItems')
+    cy.get('div[data-testid="stats-item"]').as('statsItems')
 
     cy.get('li[data-testid="legend-option"]').as('legendOptions')
   })
@@ -46,5 +46,5 @@ describe('Integration :: Player Stats', () => {
 
     cy.get('@statsItems').should('have.length', 5)
   })
-  
+
 })

--- a/cypress/integration/player-stats.spec.js
+++ b/cypress/integration/player-stats.spec.js
@@ -2,30 +2,49 @@ describe('Integration :: Player Stats', () => {
   beforeEach(() => {
     cy.setDefaultPlayer()
 
+    cy.viewport(800, 900)
+
     cy.get('button[data-testid="show-legend-selector"]').as('legendSelector')
 
-    cy.get('a[data-testid="player-search-link_mobile"]').as('playerSearchLink_mobile')
+    cy.get('a[data-testid="player-search-link_smlScreen"]').as('playerSearchLink_smlScreen')
+
+    cy.get('img[data-testid="legend-image"]').as('legendImage')
 
     cy.get('div[data-testid="stats-grid"] > div[data-testid="stats-item"]').as('statsItems')
+
+    cy.get('li[data-testid="legend-option"]').as('legendOptions')
   })
 
-  describe('Mobile view', () => {
-    beforeEach(() => {
-      cy.viewport(800, 900)
-    })
+  it('Should display stats for default player', () => {
+    cy.get('h3[data-testid="player-info"]').contains('dirtig | psn')
 
-    it('Should display stats for default player', () => {
-      cy.get('h3[data-testid="player-info"]').contains('dirtig | psn')
+    cy.get('@legendImage')
+      .invoke('attr', 'src')
+      .should('include', 'wattson-tall.png')
 
-      cy.get('img[data-testid="legend-image"]')
-        .invoke('attr', 'src')
-        .should('include', 'wattson-tall.png')
+    cy.get('@legendSelector')
+    cy.get('@playerSearchLink_smlScreen')
 
-      cy.get('@legendSelector')
-      cy.get('@playerSearchLink_mobile')
-
-      cy.get('@statsItems').should('have.length', 3)
-    })
-
+    cy.get('@statsItems').should('have.length', 3)
   })
+
+  it('Should allow the user to view a different legend', () => {
+
+    cy.get('@legendImage')
+      .invoke('attr', 'src')
+      .should('include', 'wattson-tall.png')
+
+    cy.get('@legendSelector').click()
+
+    cy.get('@legendOptions').each($option => {
+      if ($option.text() === 'Caustic') return cy.wrap($option).click()
+    })
+
+    cy.get('@legendImage')
+      .invoke('attr', 'src')
+      .should('include', 'caustic-tall.png')
+
+    cy.get('@statsItems').should('have.length', 5)
+  })
+  
 })

--- a/cypress/integration/player-stats.spec.js
+++ b/cypress/integration/player-stats.spec.js
@@ -1,0 +1,9 @@
+describe('Integration :: Player Stats', () => {
+  beforeEach(() => {
+    cy.setDefaultPlayer()
+  })
+
+  it('Should display stats for a player', () => {
+    cy.get('h3[data-testid="player-info"]').contains('dirtig | psn')
+  })
+})

--- a/cypress/integration/player-stats.spec.js
+++ b/cypress/integration/player-stats.spec.js
@@ -1,9 +1,31 @@
 describe('Integration :: Player Stats', () => {
   beforeEach(() => {
     cy.setDefaultPlayer()
+
+    cy.get('button[data-testid="show-legend-selector"]').as('legendSelector')
+
+    cy.get('a[data-testid="player-search-link_mobile"]').as('playerSearchLink_mobile')
+
+    cy.get('div[data-testid="stats-grid"] > div[data-testid="stats-item"]').as('statsItems')
   })
 
-  it('Should display stats for a player', () => {
-    cy.get('h3[data-testid="player-info"]').contains('dirtig | psn')
+  describe('Mobile view', () => {
+    beforeEach(() => {
+      cy.viewport(800, 900)
+    })
+
+    it('Should display stats for default player', () => {
+      cy.get('h3[data-testid="player-info"]').contains('dirtig | psn')
+
+      cy.get('img[data-testid="legend-image"]')
+        .invoke('attr', 'src')
+        .should('include', 'wattson-tall.png')
+
+      cy.get('@legendSelector')
+      cy.get('@playerSearchLink_mobile')
+
+      cy.get('@statsItems').should('have.length', 3)
+    })
+
   })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,7 +1,7 @@
 // Set a player session for viewing their stats, due to restrictions on
 Cypress.Commands.add("setDefaultPlayer", () => {
   // Setup the network spies
-  cy.server({ delay: 500 })
+  cy.server({ delay: 100 })
 
   cy.fixture('player-search-DiRTiG').then(response => {
     cy.route({

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,25 +1,35 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This is will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+// Set a player session for viewing their stats, due to restrictions on
+Cypress.Commands.add("setDefaultPlayer", () => {
+  // Setup the network spies
+  cy.server({ delay: 500 })
+
+  cy.fixture('player-search-DiRTiG').then(response => {
+    cy.route({
+      url: 'http://localhost:3000/apex-api/v2/apex/standard/search?platform=psn&query=DiRTiG',
+      response
+    }).as('searchDiRTiG')
+  })
+
+  cy.fixture('player-stats-DiRTiG').then(response => {
+    cy.route({
+      url: 'http://localhost:3000/apex-api/v1/apex/standard/profile/psn/dirtig',
+      response
+    }).as('DiRTiGStatsPage')
+  })
+
+  cy.visit('http://localhost:3000')
+
+  cy.get('input[name="player-tag"]').type('DiRTiG')
+
+  cy.get('button[data-testid="platform-psn"]').click()
+
+  cy.get('button[data-testid="submit-btn"]').click()
+
+  cy.wait('@searchDiRTiG')
+
+  cy.get('ul[data-testid="search-results"]')
+
+  cy.get('li[data-testid="psn-DiRTiG"]').click()
+
+  cy.wait('@DiRTiGStatsPage')
+})

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "lint:js": "prettier --write \"src/**/*.js\" && eslint --fix \"src/**/*.js\"",
     "start:dev": "webpack-dev-server",
     "cypress:open": "cypress open",
-    "build": "webpack --env.production"
+    "build": "webpack --env.production",
+    "test": "cypress run --record --key f8b075fe-ce9f-4712-ad42-96c913b58cf6"
   },
   "dependencies": {
     "linaria": "^1.4.0-alpha.1",

--- a/src/pages/PlayerStats/components/HeroSection.js
+++ b/src/pages/PlayerStats/components/HeroSection.js
@@ -49,7 +49,7 @@ const styles = {
 const HeroSection = ({ image, platformUserId, playerPlatform }) => (
   <section className={styles.container}>
     <div className={styles.playerInfo}>
-      <h3 className={styles.playerName}>
+      <h3 className={styles.playerName} data-testid="player-info">
         {platformUserId} | <span className="uppercase">{playerPlatform}</span>
       </h3>
     </div>

--- a/src/pages/PlayerStats/components/HeroSection.js
+++ b/src/pages/PlayerStats/components/HeroSection.js
@@ -54,7 +54,11 @@ const HeroSection = ({ image, platformUserId, playerPlatform }) => (
       </h3>
     </div>
     <div className={styles.legendImage}>
-      <img alt="Active Legend | Legend Alert" src={image} />
+      <img
+        alt="Active Legend | Legend Alert"
+        data-testid="legend-image"
+        src={image}
+      />
     </div>
   </section>
 );

--- a/src/pages/PlayerStats/components/LegendSelector.js
+++ b/src/pages/PlayerStats/components/LegendSelector.js
@@ -80,13 +80,14 @@ const LegendItem = styled.li`
 const LegendSelector = ({ activeLegendName, legends, onLegendSelected }) => (
   <aside className={styles.container}>
     <div className={styles.searchLinkContainer}>
-      <Link data-testid="player-search-link" to="/">
+      <Link data-testid="player-search-link_lgScreen" to="/">
         <SearchIcon color="white" width="1.25rem" />
       </Link>
     </div>
     <ul className={styles.legendList}>
       {legends.map(legend => (
         <LegendItem
+          data-testid="legend-option"
           isActiveLegend={legend.legendName === activeLegendName}
           key={legend.legendName}
           onClick={() => onLegendSelected(legend)}

--- a/src/pages/PlayerStats/components/LegendSelector.js
+++ b/src/pages/PlayerStats/components/LegendSelector.js
@@ -80,7 +80,7 @@ const LegendItem = styled.li`
 const LegendSelector = ({ activeLegendName, legends, onLegendSelected }) => (
   <aside className={styles.container}>
     <div className={styles.searchLinkContainer}>
-      <Link to="/">
+      <Link data-testid="player-search-link" to="/">
         <SearchIcon color="white" width="1.25rem" />
       </Link>
     </div>

--- a/src/pages/PlayerStats/components/NavigationBar.js
+++ b/src/pages/PlayerStats/components/NavigationBar.js
@@ -34,7 +34,7 @@ const NavigationBar = ({ hasMoreLegends = false, onShowMobileLegendList }) => (
         <ListIcon color="white" />
       </Button>
     ) : null}
-    <Link data-testid="player-search-link_mobile" to="/">
+    <Link data-testid="player-search-link_smlScreen" to="/">
       <SearchIcon color="white" />
     </Link>
   </Nav>

--- a/src/pages/PlayerStats/components/NavigationBar.js
+++ b/src/pages/PlayerStats/components/NavigationBar.js
@@ -27,11 +27,14 @@ const Nav = styled.nav`
 const NavigationBar = ({ hasMoreLegends = false, onShowMobileLegendList }) => (
   <Nav hasMoreLegends={hasMoreLegends}>
     {hasMoreLegends ? (
-      <Button onClick={onShowMobileLegendList}>
+      <Button
+        data-testid="show-legend-selector"
+        onClick={onShowMobileLegendList}
+      >
         <ListIcon color="white" />
       </Button>
     ) : null}
-    <Link to="/">
+    <Link data-testid="player-search-link_mobile" to="/">
       <SearchIcon color="white" />
     </Link>
   </Nav>

--- a/src/pages/PlayerStats/components/StatsGrid.js
+++ b/src/pages/PlayerStats/components/StatsGrid.js
@@ -68,9 +68,13 @@ const styles = {
  */
 const StatsGrid = ({ stats }) => (
   <section className={styles.container}>
-    <div className={styles.grid}>
+    <div className={styles.grid} data-testid="stats-grid">
       {stats.map(({ displayValue, metadata }) => (
-        <div className={styles.statsItem} key={metadata.key}>
+        <div
+          className={styles.statsItem}
+          data-testid="stats-item"
+          key={metadata.key}
+        >
           <div>
             <h2 className="stat-value">{displayValue}</h2>
           </div>

--- a/src/pages/PlayerStats/components/StatsGrid.js
+++ b/src/pages/PlayerStats/components/StatsGrid.js
@@ -68,7 +68,7 @@ const styles = {
  */
 const StatsGrid = ({ stats }) => (
   <section className={styles.container}>
-    <div className={styles.grid} data-testid="stats-grid">
+    <div className={styles.grid}>
       {stats.map(({ displayValue, metadata }) => (
         <div
           className={styles.statsItem}


### PR DESCRIPTION
- Adds integration tests for player stats page
- Adds cypress command for setting the player to be rendered on stats page: `cy.setDefaultPlayer()`. This only handles loading the fixture data for "DiRTiG", going forward it would nice to have ability to pass in a player's handle and platform to ensure changing players functions, however for now this is adequate.
- Adds `data-testid` to relevant components requiring targeting from integration tests
- Adds cypress config file and `projectId` 
- Adds `npm t` command for `cypress run`